### PR TITLE
Fix non-polyfill path for latest Chrome Dev 77.0.3836

### DIFF
--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -31,8 +31,8 @@ export default class p5xr {
     if(!navigator.xr) {
       window.polyfill = new WebXRPolyfill();
       this.injectedPolyfill = polyfill.injected;
+      window.versionShim = new WebXRVersionShim();
     }
-    window.versionShim = new WebXRVersionShim();
   }
 
   removeLoadingElement() {
@@ -163,6 +163,8 @@ export default class p5xr {
     } else {
       this.viewer.pose = frame.getViewerPose(this.xrFrameOfRef);
     }
+    let glLayer = this.injectedPolyfill ? session.baseLayer : session.renderState.baseLayer;
+
     // Getting the pose may fail if, for example, tracking is lost. So we
     // have to check to make sure that we got a valid pose before attempting
     // to render with it. If not in this case we'll just leave the
@@ -172,7 +174,7 @@ export default class p5xr {
       // If we do have a valid pose, bind the WebGL layer's framebuffer,
       // which is where any content to be displayed on the XRDevice must be
       // rendered.
-      this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, session.baseLayer.framebuffer);
+      this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, glLayer.framebuffer);
 
       if(this.isVR) {
         this._clearVR();
@@ -181,18 +183,20 @@ export default class p5xr {
       if(this.injectedPolyfill) {
         for(let i=0; i<frame.views.length; i++) {
           this.viewer.view = frame.views[i];
-          let viewport = session.baseLayer.getViewport(this.viewer.view);
+          let viewport = glLayer.getViewport(this.viewer.view);
           this.gl.viewport(viewport.x, viewport.y,
             viewport.width, viewport.height);
           this._drawEye(i);
         }
       } else {
+        let i=0;
         for (let view of this.viewer.pose.views) {
           this.viewer.view = view;
-          let viewport = session.baseLayer.getViewport(this.viewer.view);
+          let viewport = glLayer.getViewport(this.viewer.view);
           this.gl.viewport(viewport.x, viewport.y,
             viewport.width, viewport.height);
           this._drawEye(i);
+          i++;
         }
       }
     }

--- a/src/p5xr/p5vr/p5vr.js
+++ b/src/p5xr/p5vr/p5vr.js
@@ -87,7 +87,6 @@ export default class p5vr extends p5xr {
       // sessions baseLayer. This allows any content rendered to the layer to
       // be displayed on the XRDevice;
       this.xrSession.updateRenderState({ baseLayer: new XRWebGLLayer(this.xrSession, this.gl) });
-      // this.xrSession.baseLayer = new XRWebGLLayer(this.xrSession, this.gl);
     });
     // Get a frame of reference, which is required for querying poses. In
     // this case an 'eye-level' frame of reference means that all poses will

--- a/src/p5xr/p5vr/p5vr.js
+++ b/src/p5xr/p5vr/p5vr.js
@@ -50,7 +50,7 @@ export default class p5vr extends p5xr {
       device.requestSession({ immersive: true }).then(this.startSketch.bind(this));
     } else {
       console.log('requesting session with mode: immersive-vr');
-      navigator.xr.requestSession({mode: 'immersive-vr'}).then(this.startSketch.bind(this));
+      navigator.xr.requestSession('immersive-vr').then(this.startSketch.bind(this));
     }
     // requestSession must be called within a user gesture event
     // like click or touch when requesting an immersive session.
@@ -86,12 +86,13 @@ export default class p5vr extends p5xr {
       // Use the p5's WebGL context to create a XRWebGLLayer and set it as the
       // sessions baseLayer. This allows any content rendered to the layer to
       // be displayed on the XRDevice;
-      this.xrSession.baseLayer = new XRWebGLLayer(this.xrSession, this.gl);
+      this.xrSession.updateRenderState({ baseLayer: new XRWebGLLayer(this.xrSession, this.gl) });
+      // this.xrSession.baseLayer = new XRWebGLLayer(this.xrSession, this.gl);
     });
     // Get a frame of reference, which is required for querying poses. In
     // this case an 'eye-level' frame of reference means that all poses will
     // be relative to the location where the XRDevice was first detected.
-    this.xrSession.requestReferenceSpace({ type: 'stationary', subtype: 'eye-level' }).
+    this.xrSession.requestReferenceSpace('local').
       then((refSpace) => {
         this.xrFrameOfRef = refSpace;
         // Inform the session that we're ready to begin drawing.


### PR DESCRIPTION
This updates the code in the non-polyfill path to match the latest API present in Chrome Dev. [Testable here.](https://editor.p5js.org/stalgiag/present/japZlieXm) This does not work with the slightly newer version in Chrome Canary because `supportsSessionMode` has been deprecated in favor of `supportsSession`. I will open an issue to track this and update accordingly in a couple of days.

Next I will bring the AR non-polyfill path up to the latest API