### PR TITLE
Update Non-Polyfill Path for Chrome Canary 77.0.3838

### DIFF
--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -129,14 +129,14 @@ export default class p5xr {
         return;
       }
     } else if(this.isVR) {
-      navigator.xr.supportsSessionMode('immersive-vr').then(() => {
+      navigator.xr.supportsSession('immersive-vr').then(() => {
         console.log('VR supported without polyfill');
         // Updates the button to start an XR session when clicked.
         // HACK
         this.xrButton.setDevice(true);
       });
     } else {
-      navigator.xr.supportsSessionMode('legacy-inline-ar').then(() => {
+      navigator.xr.supportsSession('legacy-inline-ar').then(() => {
         console.log('AR supported without polyfill');
         // TEMPORARY HACK 4/7/19
         this.xrButton.setDevice(true);

--- a/src/p5xr/core/p5xrviewer.js
+++ b/src/p5xr/core/p5xrviewer.js
@@ -22,7 +22,7 @@ export default class p5xrViewer {
       p5.instance._renderer.uMVMatrix.set(this._pose.getViewMatrix(this._view));
       p5.instance._renderer.uPMatrix.set(this._view.projectionMatrix);
     } else {
-      p5.instance._renderer.uMVMatrix.set(this._view.viewMatrix);
+      p5.instance._renderer.uMVMatrix.set(this._view.transform.inverse.matrix);
       p5.instance._renderer.uPMatrix.set(this._view.projectionMatrix);
     }
   }


### PR DESCRIPTION
This updates the non-polyfill path for Chrome Canary 77.0.3838 which is the latest available version of the API.