### PR TITLE
Non-Polyfilled AR for Chrome Canary 77.0.3838

### DIFF
--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -136,7 +136,11 @@ export default class p5xr {
         this.xrButton.setDevice(true);
       });
     } else {
+<<<<<<< HEAD
       navigator.xr.supportsSession('legacy-inline-ar').then(() => {
+=======
+      navigator.xr.supportsSession('immersive-ar').then(() => {
+>>>>>>> make ar work with chrome canary 77.0.3838
         console.log('AR supported without polyfill');
         // TEMPORARY HACK 4/7/19
         this.xrButton.setDevice(true);

--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -136,11 +136,7 @@ export default class p5xr {
         this.xrButton.setDevice(true);
       });
     } else {
-<<<<<<< HEAD
-      navigator.xr.supportsSession('legacy-inline-ar').then(() => {
-=======
       navigator.xr.supportsSession('immersive-ar').then(() => {
->>>>>>> make ar work with chrome canary 77.0.3838
         console.log('AR supported without polyfill');
         // TEMPORARY HACK 4/7/19
         this.xrButton.setDevice(true);

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -6,80 +6,81 @@ export default class p5ar extends p5xr {
     // let self = p5xr.instance;
     let xrButton;
     this.canvas = null;
+  }
 
-    /**
+  /**
      * This is where the actual p5 canvas is first created, and
      * the GL rendering context is accessed by p5vr. 
      * The current XRSession also gets a frame of reference and
      * base rendering layer. <br>
      * @param {XRSession}
      */
-    this.startSketch = function(session) {
-      self.xrSession = xrButton.session = session;
-      self.xrSession.addEventListener('end', self.onSessionEnded);
-      // create p5 canvas
-      self._preloadOverride();
-      // HACK TO GET RENDERING CONTEXT 4/7/19
-      createCanvas(1,1, WEBGL);
-      self.canvas = p5.instance.canvas;
+  startSketch(session) {
+    this.xrSession = this.xrButton.session = session;
+    this.xrSession.addEventListener('end', self.onSessionEnded);
+    // create p5 canvas
+    // this._preloadOverride();
+    // HACK TO GET RENDERING CONTEXT 4/7/19
+    createCanvas(1,1, WEBGL);
+    this.canvas = p5.instance.canvas;
 
-      self.onRequestSessionNoPF();
-      p5.instance._decrementPreload();
-    };
+    if(this.injectedPolyfill) {
+      console.log('AR does not work with polyfilled version of p5.xr currently');
+      return;
+    } else {
+      this.onRequestSessionNoPF();
+    }
+    p5.instance._decrementPreload();
+  }
 
 
-    /**
-     * `device.requestSession()` must be called within a user gesture event.
-     * @param {XRDevice}
-     */
-    this.onXRButtonClicked = function(device) {
-      // Normalize the various vendor prefixed versions of getUserMedia.
-      navigator.getUserMedia = (navigator.getUserMedia ||
+  /**
+   * `device.requestSession()` must be called within a user gesture event.
+   * @param {XRDevice}
+   */
+  onXRButtonClicked(device) {
+    // Normalize the various vendor prefixed versions of getUserMedia.
+    navigator.getUserMedia = (navigator.getUserMedia ||
         navigator.webkitGetUserMedia ||
         navigator.mozGetUserMedia ||
         navigator.msGetUserMedia);
-      // AR currently uses a different canvas. 
-      let outputCanvas = document.createElement('canvas');
-      document.querySelector('header').appendChild(outputCanvas);
-      let ctx = outputCanvas.getContext('xrpresent');
-      // HACK to get close to 'fullscreen' 4/7/19
-      outputCanvas.style.width = window.innerWidth + 'px';
-      setTimeout(function() {
-        outputCanvas.style.height = window.innerHeight + 'px';
-      }, 0);
-      // HACK to get close to 'fullscreen' 4/7/19
-      xrButton.hide();
-      if(self.injectedPolyfill) {
-        // STUB
-      } else {
-        navigator.xr.requestSession({ mode: 'legacy-inline-ar', outputContext: ctx }).
-          then((session) => {
-            self.startSketch(session);
-          }, (error) => {
-            console.log(error + ' unable to request an immersive-ar session.');
-          });
-      }
-    };
-
-    this.onRequestSessionPolyfill = function() {
+    // AR currently uses a different canvas. 
+    let outputCanvas = document.createElement('canvas');
+    document.querySelector('header').appendChild(outputCanvas);
+    let ctx = outputCanvas.getContext('xrpresent');
+    // // HACK to get close to 'fullscreen' 4/7/19
+    // outputCanvas.style.width = window.innerWidth + 'px';
+    // setTimeout(function() {
+    //   outputCanvas.style.height = window.innerHeight + 'px';
+    // }, 0);
+    // // HACK to get close to 'fullscreen' 4/7/19
+    // this.xrButton.hide();
+    if(self.injectedPolyfill) {
       // STUB
-    };
-
-    this.onRequestSessionNoPF = function() {
-      console.log('set context with xrCompatible: true');
-      self.gl = self.canvas.getContext('webgl', {
-        xrCompatible: true
-      });
-      self.gl.makeXRCompatible().then(() => {
-        self.xrSession.baseLayer = new XRWebGLLayer(self.xrSession, self.gl);
-      });
-
-      self.xrSession.requestReferenceSpace({ type: 'stationary', subtype: 'eye-level' }).
-        then((refSpace) => {
-          self.xrFrameOfRef = refSpace;
-          // Inform the session that we're ready to begin drawing.
-          self.xrSession.requestAnimationFrame(self.onXRFrame);
+    } else {
+      navigator.xr.requestSession('immersive-ar').
+        then((session) => {
+          this.startSketch(session);
+        }, (error) => {
+          console.log(error + ' unable to request an immersive-ar session.');
         });
-    };
+    }
+  }
+
+  onRequestSessionNoPF() {
+    console.log('set context with xrCompatible: true');
+    this.gl = this.canvas.getContext('webgl', {
+      xrCompatible: true
+    });
+    this.gl.makeXRCompatible().then(() => {
+      this.xrSession.updateRenderState({ baseLayer: new XRWebGLLayer(this.xrSession, this.gl) });
+    });
+
+    this.xrSession.requestReferenceSpace('local').
+      then((refSpace) => {
+        this.xrFrameOfRef = refSpace;
+        // Inform the session that we're ready to begin drawing.
+        this.xrSession.requestAnimationFrame(this.onXRFrame.bind(this));
+      });
   }
 }

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -76,7 +76,7 @@ export default class p5ar extends p5xr {
       this.xrSession.updateRenderState({ baseLayer: new XRWebGLLayer(this.xrSession, this.gl) });
     });
 
-    this.xrSession.requestReferenceSpace('local').
+    this.xrSession.requestReferenceSpace('unbounded').
       then((refSpace) => {
         this.xrFrameOfRef = refSpace;
         // Inform the session that we're ready to begin drawing.

--- a/tests/manual-test-examples/p5ar/basic/example.js
+++ b/tests/manual-test-examples/p5ar/basic/example.js
@@ -1,12 +1,12 @@
-function setup(){
+function setup() {
   createARCanvas();
 }
 
 let counter = 0;
 
-function draw(){
+function draw() {
   // TEMPORARY HACK
-  if(counter < 2){counter++; return;}
+  if(counter < 2) {counter++; return;}
   translate(0, 0, 100);
   fill(100,240,100);
   stroke(200, 0, 200);


### PR DESCRIPTION
This fixes the non-polyfilled AR for Chrome Canary 77.0.3838 which is the most recently available version of API. [Example here, ](https://editor.p5js.org/stalgiag/present/1wzwzI2uG)flags apply

closes #40