### PR TITLE
Add rotateX(PI) to surroundTexture, fix examples

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -64,6 +64,7 @@ p5.prototype.setVRBackgroundColor = function (r, g, b) {
 p5.prototype.surroundTexture = function (tex) {
   push();
   texture(tex);
+  rotateX(PI);
   scale(-1, 1, 1);
   sphere(300, 60, 40);
   pop();

--- a/tests/manual-test-examples/p5vr/material/360CanvasViewer/sketch.js
+++ b/tests/manual-test-examples/p5vr/material/360CanvasViewer/sketch.js
@@ -4,7 +4,7 @@ let tex;
 let bugs = []; // array of Jitter objects
 
 function preload() {
-  tex = createGraphics(1000,1000);
+  tex = createGraphics(1000, 1000);
   createVRCanvas();
 }
 
@@ -22,7 +22,6 @@ function draw() {
     bugs[i].display();
   }
 
-  rotateX(PI);
   surroundTexture(tex);
 }
 

--- a/tests/manual-test-examples/p5vr/material/360PhotoViewer/sketch.js
+++ b/tests/manual-test-examples/p5vr/material/360PhotoViewer/sketch.js
@@ -20,7 +20,6 @@ function calculate() {
 }
 
 function draw() {
-  rotateX(PI);
   surroundTexture(tex);
   translate(0, 0, 35);
   rotateY(rot);

--- a/tests/manual-test-examples/p5vr/material/360VideoViewer/sketch.js
+++ b/tests/manual-test-examples/p5vr/material/360VideoViewer/sketch.js
@@ -10,7 +10,6 @@ function preload() {
 }
 
 function draw() {
-  rotateX(PI);
   surroundTexture(vid);
 }
 


### PR DESCRIPTION
Added rotateX(PI) to surroundTexture as indicated in #90 