### PR TITLE
fix: move objects in front in manual test

### DIFF
--- a/tests/manual-test-examples/p5vr/basic/example.js
+++ b/tests/manual-test-examples/p5vr/basic/example.js
@@ -19,7 +19,7 @@ function calculate() {
 
 function draw() {
   fill(0, 255, 0);
-  translate(0, 0, 10);
+  translate(0, 0, -10);
   rotateX(10);
   rotateY(20);
   strokeWeight(5);

--- a/tests/manual-test-examples/p5vr/two-d/example.js
+++ b/tests/manual-test-examples/p5vr/two-d/example.js
@@ -31,7 +31,7 @@ function draw() {
   pg.ellipse(pg.width/2, pg.height/2, 100);
   pg.fill(255);
   pg.ellipse(pos.x, pos.y, 20);
-  translate(0, 0, 10);
+  translate(0, 0, -10);
   noStroke();
   texture(pg);
   rotateY(frameCount * 0.02);


### PR DESCRIPTION
Moving objects in front of camera for manual tests. Quality of life improvement for debugging, so you don't have to turn your head in VR in order to validate the manual tests