### PR TITLE
fix: moving toon shader object in front of user

### DIFF
--- a/tests/manual-test-examples/p5vr/customShader/toonShader/sketch.js
+++ b/tests/manual-test-examples/p5vr/customShader/toonShader/sketch.js
@@ -7,7 +7,7 @@ function preload() {
 }
 
 function draw() {
-  translate(0, 0, 10);
+  translate(0, 0, -10);
   noStroke();
   // Custom shaders temporarily broken
   shader(toonShader);


### PR DESCRIPTION
Identical reason as #170 
Moving toon shader object in front of user so tester does not need to turn around to view