### PR TITLE
Feat/p5mr

### DIFF
--- a/examples/hello-box/hello-box.js
+++ b/examples/hello-box/hello-box.js
@@ -1,0 +1,13 @@
+function preload() {
+  createMRCanvas();
+}
+
+function setup() {
+}
+
+function draw() {
+  push();
+  translate(0, 0, -0.3);
+  box(0.1, 0.1, 0.1);
+  pop();
+}

--- a/examples/hello-box/index.html
+++ b/examples/hello-box/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>
+    <meta name='mobile-web-app-capable' content='yes'>
+    <meta name='apple-mobile-web-app-capable' content='yes'>
+
+    <title>MR EXAMPLE #1 : HELLO BOX </title>
+    <script src='../../../node_modules/p5/lib/p5.js'></script>
+    <script src='../../../dist/p5xr.min.js'></script>
+  </head>
+  <body>
+    <header></header>
+    <script src="hello-box.js"></script>
+  </body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import p5vr from './p5xr/p5vr/p5vr';
 import p5ar from './p5xr/p5ar/p5ar';
+import p5mr from './p5xr/p5mr/p5mr';
 
 window.p5xr = {
   instance: null,
@@ -47,6 +48,22 @@ p5.prototype.createARCanvas = function () {
   noLoop();
   p5xr.instance = new p5ar();
   p5xr.instance.initAR();
+};
+
+/**
+ * This creates a button that will create a AR canvas and new p5mr object
+ * on click. p5mr is for headset based AR with pass-through cameras.
+ * This should be called in `preload()` so
+ * that the entire sketch can wait to start until the user has "entered AR"
+ * via a button click gesture/
+ * @method createMRCanvas
+ * @section AR
+ * @category Initialization
+ */
+p5.prototype.createMRCanvas = function () {
+  noLoop();
+  p5xr.instance = new p5mr();
+  p5xr.instance.__initMR();
 };
 
 /**
@@ -155,7 +172,7 @@ p5.prototype.surroundTexture = function (tex) {
  * @section AR
  */
 p5.prototype.createAnchor = function (vec) {
-  if (p5xr.instance.isVR) {
+  if (p5xr.instance.mode === 'VR') {
     return;
   }
   return p5xr.instance.__createAnchor(vec);
@@ -165,7 +182,7 @@ p5.prototype.createAnchor = function (vec) {
  * @ignore
  */
 p5.prototype.detectHit = function (ev) {
-  if (p5xr.instance.isVR) {
+  if (p5xr.instance.mode === 'VR') {
     return;
   }
   return p5xr.instance.__detectHit(ev);

--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -19,7 +19,7 @@ export default class p5xr {
   constructor(xrButton) {
     this.xrDevice = null;
     this.xrButton = xrButton || null;
-    this.isVR = null;
+    this.mode = null; // VR, AR or MR
     this.hasImmersive = null;
     this.xrSession = null;
     this.xrRefSpace = null;
@@ -125,8 +125,8 @@ export default class p5xr {
     // WebXR availabilty
     if (navigator?.xr) {
       console.log('XR Available');
-      const mode = this.isVR ? 'VR' : 'AR';
-      const session = this.isVR ? 'immersive-vr' : 'immersive-ar';
+      const mode = this.mode;
+      const session = this.mode === 'VR' ? 'immersive-vr' : 'immersive-ar';
       const supported = await navigator.xr.isSessionSupported(session);
       this.hasImmersive = supported;
       this.xrButton.setAvailable(supported, mode);
@@ -154,7 +154,7 @@ export default class p5xr {
     session.requestAnimationFrame(this.__onXRFrame.bind(this));
 
     let targetRefSpace = this.xrRefSpace;
-    if (this.isVR && !this.isImmersive) {
+    if (this.mode === 'VR' && !this.isImmersive) {
       // Account for the click-and-drag mouse movement or touch movement when
       // calculating the viewer pose for inline sessions.
       targetRefSpace = this.getAdjustedRefSpace(this.xrRefSpace);
@@ -176,7 +176,7 @@ export default class p5xr {
       // rendered.
       this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, glLayer.framebuffer);
 
-      if (this.isVR) {
+      if (this.mode === 'VR') {
         this.clearVR();
       }
 
@@ -225,7 +225,7 @@ export default class p5xr {
     const userDraw = context.draw;
     const userCalculate = context.calculate;
 
-    if (this.isVR) {
+    if (this.mode === 'VR' || this.mode === 'MR') {
       if (eyeIndex === 0) {
         if (typeof userCalculate === 'function') {
           userCalculate();
@@ -291,7 +291,7 @@ export default class p5xr {
    * @ignore
    */
   __onSessionEnded() {
-    if (!this.isVR) {
+    if (!(this.mode === 'VR')) {
       this.xrHitTestSource.cancel();
       this.xrHitTestSource = null;
     } else if (this.isImmersive) {

--- a/src/p5xr/p5mr/p5mr.js
+++ b/src/p5xr/p5mr/p5mr.js
@@ -2,17 +2,17 @@ import { quat } from 'gl-matrix';
 import p5xr from '../core/p5xr';
 
 /**
- * p5vr class holds all state and methods that are specific to VR
+ * p5vr class holds all state and methods that are specific to MR ( headset based AR )
  * @class
  * @private
  * @constructor
  * @ignore
  */
 
-export default class p5vr extends p5xr {
+export default class p5mr extends p5xr {
   constructor() {
     super();
-    this.mode = 'VR';
+    this.mode = 'MR';
     this.isImmersive = false;
     this.lookYaw = 0;
     this.lookPitch = 0;
@@ -33,13 +33,14 @@ export default class p5vr extends p5xr {
    * @private
    * @ignore
    */
-  __initVR() {
+  __initMR() {
+    console.log("create button");
     this.__createButton();
   }
 
   /**
    * This is where the actual p5 canvas is first created, and
-   * the GL rendering context is accessed by p5vr.
+   * the GL rendering context is accessed by p5mr.
    * The current XRSession also gets a frame of reference and
    * base rendering layer. <br>
    * @param {XRSession}
@@ -56,7 +57,7 @@ export default class p5vr extends p5xr {
       window.setup();
       p5.instance._millisStart = window.performance.now();
     }
-    const refSpaceRequest = this.isImmersive ? 'local' : 'viewer';
+    const refSpaceRequest = this.isImmersive ? 'local-floor' : 'viewer';
     this.xrSession.requestReferenceSpace(refSpaceRequest).then((refSpace) => {
       this.xrRefSpace = refSpace;
       // Inform the session that we're ready to begin drawing.
@@ -88,18 +89,18 @@ export default class p5vr extends p5xr {
   }
 
   /**
-   * `navigator.xr.requestSession('immersive-vr')` must be called within a user gesture event.
+   * `navigator.xr.requestSession('immersive-ar')` must be called within a user gesture event.
    * @param {XRDevice}
    * @private
    * @ignore
    */
   __onXRButtonClicked() {
     if (this.hasImmersive) {
-      console.log('Requesting session with mode: immersive-vr');
+      console.log('Requesting MR session with mode: immersive-ar');
       this.isImmersive = true;
       this.resetXR();
       navigator.xr
-        .requestSession('immersive-vr')
+        .requestSession('immersive-ar')
         .then(this.__startSketch.bind(this));
     } else {
       this.xrButton.hide();
@@ -114,13 +115,13 @@ export default class p5vr extends p5xr {
   __onRequestSession() {
     p5.instance._renderer._curCamera.cameraType = 'custom';
     const refSpaceRequest = this.isImmersive ? 'local' : 'viewer';
-
-    this.gl = this.canvas.getContext(p5.instance.webglVersion);
+    console.log('Requesting reference space with mode: ' + refSpaceRequest);
+    this.gl = this.canvas.getContext('webgl');
     this.gl
       .makeXRCompatible()
       .then(() => {
         // Get a frame of reference, which is required for querying poses.
-        // 'local' places the initial pose relative to initial location of viewer
+        // space request types https://developer.mozilla.org/en-US/docs/Web/API/XRSession/requestReferenceSpace
         // 'viewer' is only for inline experiences and only allows rotation
         this.xrSession
           .requestReferenceSpace(refSpaceRequest)
@@ -152,7 +153,6 @@ export default class p5vr extends p5xr {
     if (this.curClearColor === null) {
       return;
     }
-    p5.instance.background(this.curClearColor);
 
     this.gl.clear(this.gl.DEPTH_BUFFER_BIT);
   }

--- a/tests/unit/p5xr/core/p5xr.js
+++ b/tests/unit/p5xr/core/p5xr.js
@@ -19,10 +19,10 @@ suite('p5xr', function() {
   });
   
   suite('init()', function() {
-    test('p5xr.isVR is true for VR sketch', function() {
+    test('p5xr mode is VR for VR sketch', function() {
       p5xr.instance = new p5vr();
       p5xr.instance.__initVR();
-      assert.isTrue(p5xr.instance.isVR);
+      assert.isTrue(p5xr.instance.mode === 'VR');
       p5xr.instance.remove();
     });
     


### PR DESCRIPTION
I created `p5mr` in addition to `p5ar` and `p5vr`. I find that the modern headsets have rendering more similar to how the `p5vr` functions at the moment. 

I think this might be an anti-pattern as far as the web goes, for progressive enhancement, but it might be the way to go for a p5 wrapper. 

Do you have any thoughts on what would be a good way to handle these types of headsets/devices with passthrough? 