### PR TITLE
Readme p5.xr min version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ p5.xr sketches can be run with [p5's online editor.](https://editor.p5js.org/) A
   - Do some simple raycasting for gaze-based interaction in both AR and VR
 
 ## Getting Started
-1. Make sure that you have [the most recent version of p5.js](https://p5js.org/download/).
+1. Use the [the most recent version of p5.js](https://p5js.org/download/) or at least version `1.7.0`.
 2. Check out the [Device and Browser Support Section](https://stalgiag.github.io/p5.xr/#/quick-start/device-support).
 3. Add p5.xr to your project. This can be done most easily by adding the script link to a CDN in the `<head>` of your HTML file underneath the p5 link:
     ```
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.5.0/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/p5.xr/dist/p5xr.min.js"></script>
     ```
 4. Change the `createCanvas()` call in your p5 WEBGL sketch to `createVRCanvas()` and put it in `preload()` -or-


### PR DESCRIPTION
WebGL2 support and p5.instance.webglVersion check was introduced in version 1.7.0 https://github.com/processing/p5.js/releases/tag/v1.7.0. Getting webgl context will fail if in older versions. Example mentioned in #203 currently fails because of this.

p5 editor examples should be updated if possible.