### PR TITLE
Refactor / p5xr consolidation / Fix AR mode

### DIFF
--- a/examples/ar/hello-cube/example.js
+++ b/examples/ar/hello-cube/example.js
@@ -1,0 +1,14 @@
+function preload() {
+  createARCanvas();
+}
+
+function setup() {
+  describe("A cube waiting to be seen");
+}
+
+function draw() {
+  push();
+  translate(0, 0, -0.4);
+  box(0.1, 0.1, 0.1);
+  pop();
+}

--- a/examples/ar/hello-cube/index.html
+++ b/examples/ar/hello-cube/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>
+    <meta name='mobile-web-app-capable' content='yes'>
+    <meta name='apple-mobile-web-app-capable' content='yes'>
+
+    <title>AR EXAMPLE #1 : Hello Cube</title>
+    <script src='../../../node_modules/p5/lib/p5.js'></script>
+    <script src='../../../dist/p5xr.min.js'></script>
+  </head>
+  <body>
+    <header></header>
+    <script src="example.js"></script>
+  </body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -26,10 +26,9 @@ window.p5xr = {
  * @section VR
  * @category Initialization
  */
-p5.prototype.createVRCanvas = function (xrButton) {
+p5.prototype.createVRCanvas = function () {
   noLoop();
-  p5xr.instance = new p5vr(xrButton);
-  p5xr.instance.__initVR();
+  p5xr.instance = new p5vr();
 };
 
 /**
@@ -46,7 +45,6 @@ p5.prototype.createVRCanvas = function (xrButton) {
 p5.prototype.createARCanvas = function () {
   noLoop();
   p5xr.instance = new p5ar();
-  p5xr.instance.initAR();
 };
 
 /**

--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -340,7 +340,7 @@ export default class p5xr {
           viewport.x,
           viewport.y,
           viewport.width * scaleFactor,
-          viewport.height * scaleFactor
+          viewport.height * scaleFactor,
         );
         this.__updateViewport(viewport);
 
@@ -370,7 +370,7 @@ export default class p5xr {
    * @private
    * @ignore
    */
-  __drawEye(eyeIndex) {
+  __drawEye() {
     const context = window;
     const userSetup = context.setup;
     const userDraw = context.draw;
@@ -446,9 +446,9 @@ export default class p5xr {
    */
   printUnsupportedMessage() {
     console.warn(
-      'Your browser/hardware does not work with AR Mode currently. This is' +
-        ' undergoing heavy development currently.' +
-        'You may be able to fix this by enabling WebXR flags in Chrome.'
+      'Your browser/hardware does not work with AR Mode currently. This is'
+        + ' undergoing heavy development currently.'
+        + 'You may be able to fix this by enabling WebXR flags in Chrome.',
     );
   }
 

--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -16,9 +16,8 @@ import p5xrInput from './p5xrInput';
  * @property curClearColor  {Color} background clear color set by global `setVRBackgroundColor`
  */
 export default class p5xr {
-  constructor(xrButton) {
+  constructor() {
     this.xrDevice = null;
-    this.xrButton = xrButton || null;
     this.isVR = null;
     this.hasImmersive = null;
     this.xrSession = null;

--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -8,6 +8,7 @@ import p5xrInput from './p5xrInput';
  *
  * @constructor
  *
+ * @property mode  {"inline" | "immersive-ar" | "immersive-vr"} WebXR session mode
  * @property vrDevice  {XRDevice} the current VR compatible device
  * @property vrSession  {XRSession} the current VR session
  * @property vrFrameOfRef  {XRFrameOfReference} the current VR frame of reference
@@ -19,6 +20,7 @@ export default class p5xr {
   constructor() {
     this.xrDevice = null;
     this.isVR = null;
+    this.mode = 'inline';
     this.hasImmersive = null;
     this.isImmersive = false;
     this.xrSession = null;
@@ -27,7 +29,7 @@ export default class p5xr {
     this.xrHitTestSource = null;
     this.frame = null;
     this.gl = null;
-    this.curClearColor = color(255, 255, 255);
+    this.curClearColor = color(256, 255, 255);
     this.viewer = new p5xrViewer();
   }
 
@@ -125,11 +127,9 @@ export default class p5xr {
     // WebXR availabilty
     if (navigator?.xr) {
       console.log('XR Available');
-      const mode = this.isVR ? 'VR' : 'AR';
-      const session = this.isVR ? 'immersive-vr' : 'immersive-ar';
-      const supported = await navigator.xr.isSessionSupported(session);
+      const supported = await navigator.xr.isSessionSupported(this.mode);
       this.hasImmersive = supported;
-      this.xrButton.setAvailable(supported, mode);
+      this.xrButton.setAvailable(supported, this.mode);
     } else {
       console.log('XR Not Available');
       this.xrButton.disable();

--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -20,6 +20,7 @@ export default class p5xr {
     this.xrDevice = null;
     this.isVR = null;
     this.hasImmersive = null;
+    this.isImmersive = false;
     this.xrSession = null;
     this.xrRefSpace = null;
     this.xrViewerSpace = null;

--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -43,7 +43,7 @@ export default class p5xr {
     this.xrHitTestSource = null;
     this.frame = null;
     this.gl = null;
-    this.curClearColor = color(256, 255, 255);
+    this.curClearColor = color(255, 255, 255);
     this.viewer = new p5xrViewer();
 
     this.requiredFeatures = requiredFeatures;
@@ -210,19 +210,19 @@ export default class p5xr {
       window.setup();
       p5.instance._millisStart = window.performance.now();
     }
-    // const refSpaceRequest = this.isImmersive ? 'local' : 'viewer';
-    // this.xrSession.requestReferenceSpace(refSpaceRequest).then((refSpace) => {
-    //   this.xrRefSpace = refSpace;
-    //   // Inform the session that we're ready to begin drawing.
-    //   this.xrSession.requestAnimationFrame(this.__onXRFrame.bind(this));
-    //   if (!this.isImmersive) {
-    //     this.xrSession.updateRenderState({
-    //       baseLayer: new XRWebGLLayer(this.xrSession, this.gl),
-    //       inlineVerticalFieldOfView: 70 * (Math.PI / 180),
-    //     });
-    //     this.addInlineViewListeners(this.canvas);
-    //   }
-    // });
+    const refSpaceRequest = this.isImmersive ? 'local' : 'viewer';
+    this.xrSession.requestReferenceSpace(refSpaceRequest).then((refSpace) => {
+      this.xrRefSpace = refSpace;
+      // Inform the session that we're ready to begin drawing.
+      this.xrSession.requestAnimationFrame(this.__onXRFrame.bind(this));
+      if (!this.isImmersive) {
+        this.xrSession.updateRenderState({
+          baseLayer: new XRWebGLLayer(this.xrSession, this.gl),
+          inlineVerticalFieldOfView: 70 * (Math.PI / 180),
+        });
+        this.addInlineViewListeners(this.canvas);
+      }
+    });
     this.__onRequestSession();
   }
 

--- a/src/p5xr/core/p5xrButton.js
+++ b/src/p5xr/core/p5xrButton.js
@@ -422,18 +422,19 @@ class p5xrButton {
    * Set button state based on mode support
    */
   setAvailable(isAvailable, mode) {
+    const displayMode = mode.slice(-2).toUpperCase();
     if (isAvailable) {
-      const msg = `Enter ${mode}`;
+      const msg = `Enter ${displayMode}`;
       this.setTitle(msg);
       this.setTooltip(msg);
       this.enable();
       console.log(`${mode} supported`);
       this.setDevice(true);
-    } else if (mode === 'VR') {
+    } else if (displayMode === 'VR') {
       console.log('VR not supported. Falling back to inline mode.');
       this.hide();
     } else {
-      const msg = `${mode} not supported`;
+      const msg = `${displayMode} not supported`;
       this.setTitle(msg);
       this.setTooltip(msg);
       this.disable();

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -4,6 +4,7 @@ import ARAnchor from './ARAnchor';
 export default class p5ar extends p5xr {
   constructor() {
     super();
+    this.mode = 'immersive-ar';
     this.canvas = null;
     this.__createButton();
   }

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -102,13 +102,6 @@ export default class p5ar extends p5xr {
    * @ignore
    */
   __onXRButtonClicked() {
-    // Normalize the various vendor prefixed versions of getUserMedia.
-    navigator.getUserMedia =
-      navigator.getUserMedia ||
-      navigator.webkitGetUserMedia ||
-      navigator.mozGetUserMedia ||
-      navigator.msGetUserMedia;
-
     navigator.xr
       .requestSession('immersive-ar', {
         requiredFeatures: ['local', 'hit-test'],

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -25,15 +25,11 @@ export default class p5ar extends p5xr {
    * @ignore
    */
   __startSketch(session) {
-    this.xrSession = this.xrButton.session = session;
-    this.xrSession.addEventListener('end', this.__onSessionEnded);
+    super.__startSketch(session);
+
     if (typeof touchStarted === 'function') {
       this.xrSession.addEventListener('select', touchStarted);
     }
-    this.canvas = p5.instance.canvas;
-    p5.instance._renderer._curCamera.cameraType = 'custom';
-    this.__onRequestSession();
-    p5.instance._decrementPreload();
   }
 
   /**
@@ -93,35 +89,5 @@ export default class p5ar extends p5xr {
       return null;
     }
     return new ARAnchor(vec.x, vec.y, vec.z);
-  }
-
-  /**
-   * @private
-   * @ignore
-   */
-  __onRequestSession() {
-    this.gl = this.canvas.getContext(p5.instance.webglVersion, {
-      xrCompatible: true,
-    });
-    this.gl.makeXRCompatible().then(() => {
-      this.xrSession.updateRenderState({
-        baseLayer: new XRWebGLLayer(this.xrSession, this.gl),
-      });
-    });
-
-    this.xrSession.requestReferenceSpace('viewer').then((refSpace) => {
-      this.xrViewerSpace = refSpace;
-      this.xrSession
-        .requestHitTestSource({ space: this.xrViewerSpace })
-        .then((hitTestSource) => {
-          this.xrHitTestSource = hitTestSource;
-        });
-    });
-
-    this.xrSession.requestReferenceSpace('local').then((refSpace) => {
-      this.xrRefSpace = refSpace;
-      // Inform the session that we're ready to begin drawing.
-      this.xrSession.requestAnimationFrame(this.__onXRFrame.bind(this));
-    });
   }
 }

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -3,7 +3,9 @@ import ARAnchor from './ARAnchor';
 
 export default class p5ar extends p5xr {
   constructor() {
-    super();
+    super({
+      requiredFeatures: ['local', 'hit-test'],
+    });
     this.mode = 'immersive-ar';
     this.canvas = null;
     this.__createButton();
@@ -91,27 +93,6 @@ export default class p5ar extends p5xr {
       return null;
     }
     return new ARAnchor(vec.x, vec.y, vec.z);
-  }
-
-  /**
-   * `device.requestSession()` must be called within a user gesture event.
-   * @param {XRDevice}
-   * @private
-   * @ignore
-   */
-  __onXRButtonClicked() {
-    navigator.xr
-      .requestSession('immersive-ar', {
-        requiredFeatures: ['local', 'hit-test'],
-      })
-      .then(
-        (session) => {
-          this.__startSketch(session);
-        },
-        (error) => {
-          console.log(`${error} unable to request an immersive-ar session.`);
-        }
-      );
   }
 
   /**

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -71,7 +71,7 @@ export default class p5ar extends p5xr {
         return createVector(
           pose.transform.position.x,
           pose.transform.position.y,
-          pose.transform.position.z
+          pose.transform.position.z,
         );
       }
     }

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -9,10 +9,6 @@ export default class p5ar extends p5xr {
 
   initAR() {
     this.__createButton();
-    // WebXR available
-    if (navigator?.xr) {
-      this.__sessionCheck();
-    }
   }
 
   //* ********************************************************//

--- a/src/p5xr/p5ar/p5ar.js
+++ b/src/p5xr/p5ar/p5ar.js
@@ -5,9 +5,6 @@ export default class p5ar extends p5xr {
   constructor() {
     super();
     this.canvas = null;
-  }
-
-  initAR() {
     this.__createButton();
   }
 

--- a/src/p5xr/p5vr/p5vr.js
+++ b/src/p5xr/p5vr/p5vr.js
@@ -75,7 +75,7 @@ export default class p5vr extends p5xr {
         y: invOrientation[1],
         z: invOrientation[2],
         w: invOrientation[3],
-      }
+      },
     );
     return refSpace.getOffsetReferenceSpace(xform);
   }
@@ -130,7 +130,7 @@ export default class p5vr extends p5xr {
           this.primaryTouch = undefined;
           this.rotateInlineView(
             touch.pageX - this.prevTouchX,
-            touch.pageY - this.prevTouchY
+            touch.pageY - this.prevTouchY,
           );
         }
       }
@@ -154,7 +154,7 @@ export default class p5vr extends p5xr {
         if (this.primaryTouch === touch.identifier) {
           this.rotateInlineView(
             touch.pageX - this.prevTouchX,
-            touch.pageY - this.prevTouchY
+            touch.pageY - this.prevTouchY,
           );
           this.prevTouchX = touch.pageX;
           this.prevTouchY = touch.pageY;

--- a/src/p5xr/p5vr/p5vr.js
+++ b/src/p5xr/p5vr/p5vr.js
@@ -38,67 +38,7 @@ export default class p5vr extends p5xr {
    * @ignore
    */
   __startSketch(session) {
-    this.xrSession = session;
-    this.canvas = p5.instance.canvas;
-    this.canvas.style.visibility = 'visible';
-
-    this.xrSession.addEventListener('end', this.__onSessionEnded.bind(this));
-    if (typeof window.setup === 'function') {
-      window.setup();
-      p5.instance._millisStart = window.performance.now();
-    }
-    const refSpaceRequest = this.isImmersive ? 'local' : 'viewer';
-    this.xrSession.requestReferenceSpace(refSpaceRequest).then((refSpace) => {
-      this.xrRefSpace = refSpace;
-      // Inform the session that we're ready to begin drawing.
-      this.xrSession.requestAnimationFrame(this.__onXRFrame.bind(this));
-      if (!this.isImmersive) {
-        this.xrSession.updateRenderState({
-          baseLayer: new XRWebGLLayer(this.xrSession, this.gl),
-          inlineVerticalFieldOfView: 70 * (Math.PI / 180),
-        });
-        this.addInlineViewListeners(this.canvas);
-      }
-    });
-    this.__onRequestSession();
-  }
-
-
-  /**
-   * Requests a reference space and makes the p5's WebGL layer XR compatible.
-   * @private
-   * @ignore
-   */
-  __onRequestSession() {
-    p5.instance._renderer._curCamera.cameraType = 'custom';
-    const refSpaceRequest = this.isImmersive ? 'local' : 'viewer';
-
-    this.gl = this.canvas.getContext(p5.instance.webglVersion);
-    this.gl
-      .makeXRCompatible()
-      .then(() => {
-        // Get a frame of reference, which is required for querying poses.
-        // 'local' places the initial pose relative to initial location of viewer
-        // 'viewer' is only for inline experiences and only allows rotation
-        this.xrSession
-          .requestReferenceSpace(refSpaceRequest)
-          .then((refSpace) => {
-            this.xrRefSpace = refSpace;
-          });
-
-        // Use the p5's WebGL context to create a XRWebGLLayer and set it as the
-        // sessions baseLayer. This allows any content rendered to the layer to
-        // be displayed on the XRDevice;
-        this.xrSession.updateRenderState({
-          baseLayer: new XRWebGLLayer(this.xrSession, this.gl),
-        });
-      })
-      .catch((e) => {
-        console.log(e);
-      });
-
-    // Request initial animation frame
-    this.xrSession.requestAnimationFrame(this.__onXRFrame.bind(this));
+    super.__startSketch(session);
   }
 
   /**

--- a/src/p5xr/p5vr/p5vr.js
+++ b/src/p5xr/p5vr/p5vr.js
@@ -25,15 +25,6 @@ export default class p5vr extends p5xr {
     if (navigator?.xr) {
       navigator.xr.requestSession('inline').then(this.__startSketch.bind(this));
     }
-  }
-
-  /**
-   * Currently a stub function that just creates a button
-   * Previously handled more, now can be replaced with refactor
-   * @private
-   * @ignore
-   */
-  __initVR() {
     this.__createButton();
   }
 

--- a/src/p5xr/p5vr/p5vr.js
+++ b/src/p5xr/p5vr/p5vr.js
@@ -13,7 +13,6 @@ export default class p5vr extends p5xr {
   constructor() {
     super();
     this.isVR = true;
-    this.isImmersive = false;
     this.lookYaw = 0;
     this.lookPitch = 0;
     this.LOOK_SPEED = 0.0025;

--- a/src/p5xr/p5vr/p5vr.js
+++ b/src/p5xr/p5vr/p5vr.js
@@ -63,39 +63,6 @@ export default class p5vr extends p5xr {
     this.__onRequestSession();
   }
 
-  /**
-   * Helper function to reset XR and GL, should be called between
-   * ending an XR session and starting a new XR session
-   * @method resetXR
-   */
-  resetXR() {
-    this.xrDevice = null;
-    this.xrSession = null;
-    this.xrRefSpace = null;
-    this.xrViewerSpace = null;
-    this.xrHitTestSource = null;
-    this.gl = null;
-    this.frame = null;
-  }
-
-  /**
-   * `navigator.xr.requestSession('immersive-vr')` must be called within a user gesture event.
-   * @param {XRDevice}
-   * @private
-   * @ignore
-   */
-  __onXRButtonClicked() {
-    if (this.hasImmersive) {
-      console.log('Requesting session with mode: immersive-vr');
-      this.isImmersive = true;
-      this.resetXR();
-      navigator.xr
-        .requestSession('immersive-vr')
-        .then(this.__startSketch.bind(this));
-    } else {
-      this.xrButton.hide();
-    }
-  }
 
   /**
    * Requests a reference space and makes the p5's WebGL layer XR compatible.

--- a/src/p5xr/p5vr/p5vr.js
+++ b/src/p5xr/p5vr/p5vr.js
@@ -12,6 +12,7 @@ import p5xr from '../core/p5xr';
 export default class p5vr extends p5xr {
   constructor() {
     super();
+    this.mode = 'immersive-vr';
     this.isVR = true;
     this.lookYaw = 0;
     this.lookPitch = 0;

--- a/tests/unit/p5xr/core/p5xr.js
+++ b/tests/unit/p5xr/core/p5xr.js
@@ -21,7 +21,6 @@ suite('p5xr', function() {
   suite('init()', function() {
     test('p5xr.isVR is true for VR sketch', function() {
       p5xr.instance = new p5vr();
-      p5xr.instance.__initVR();
       assert.isTrue(p5xr.instance.isVR);
       p5xr.instance.remove();
     });
@@ -30,7 +29,6 @@ suite('p5xr', function() {
       sinon.spy(window, 'setup');
       window.preload = function() {
         p5xr.instance = new p5vr();
-        p5xr.instance.__initVR();
       };
       myp5.remove();
       myp5 = new p5();
@@ -40,17 +38,15 @@ suite('p5xr', function() {
     });
 
     test('p5xr.__removeLoadingElement() is called', function() {
+      sinon.spy(p5vr.prototype, '__removeLoadingElement');
       p5xr.instance = new p5vr();
-      sinon.spy(p5xr.instance, '__removeLoadingElement');
-      p5xr.instance.__initVR();
-      sinon.assert.called(p5xr.instance.__removeLoadingElement);
-      p5xr.instance.__removeLoadingElement.restore();
+      sinon.assert.called(p5vr.prototype.__removeLoadingElement);
+      p5vr.prototype.__removeLoadingElement.restore();
       p5xr.instance.remove();
     });
 
     test('xrButton is set and added in DOM', function() {
       p5xr.instance = new p5vr();
-      p5xr.instance.__initVR();
       assert.instanceOf(p5xr.instance.xrButton, p5xrButton);
       let button = document.querySelector('header button');
       assert.equal(button.tagName, 'BUTTON');
@@ -58,11 +54,10 @@ suite('p5xr', function() {
     });
 
     test('p5xr.__sessionCheck() is called', function() {
+      sinon.spy(p5vr.prototype, '__sessionCheck');
       p5xr.instance = new p5vr();
-      sinon.spy(p5xr.instance, '__sessionCheck');
-      p5xr.instance.__initVR();
-      sinon.assert.called(p5xr.instance.__sessionCheck);
-      p5xr.instance.__sessionCheck.restore();
+      sinon.assert.called(p5vr.prototype.__sessionCheck);
+      p5vr.prototype.__sessionCheck.restore();
       p5xr.instance.remove();
     });
   });
@@ -71,7 +66,6 @@ suite('p5xr', function() {
     test('removes p5 loading element from DOM', function() {
       window.preload = function() {
         p5xr.instance = new p5vr();
-        p5xr.instance.__initVR();
         let loading = document.getElementById(window._loadingScreenId);
         assert.isNull(loading);
       };


### PR DESCRIPTION
As discussed in #207, this PR consolidates common code between `p5xr` and `p5ar` into `p5xr` in preparation for a more feature based approach. Initially I was looking to fix AR mode for the use with my Quest 3, but doing the refactor at the same time made the most sense.

Let me know if you would like me to squash the commits into a single one, or if you prefer "atomic commits".

Here are the changes in reverse chronological order:
* Hello cube AR example
* Fix tests for launching from constructor
* Consolidated common startsketch and request session into p5xr
    Removed p5.instance._decrementPreload as it was launching p5 in 2D mode for
    some reason
* Moved common requestSession code into p5xr from p5ar and p5vr
* Favour explicited WebXR modes
* Moved isImmersive to XR level, AR and VR can both be immersive
* Removed superfluous init functions, create buttons in constructors
    Removed button argument because it was always created and overloaded afer
    construction
* Removed deprecated navigator.getUserMedia()
    https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia
