### PR TITLE
feat: p5LIVE live coding inside immersive ar or vr session by reusing existing xrSession

### DIFF
--- a/src/p5xr/core/p5xrViewer.js
+++ b/src/p5xr/core/p5xrViewer.js
@@ -41,16 +41,17 @@ class p5xrViewer {
    */
   set view(newView) {
     this._view = newView;
+    const renderer = p5.instance._renderer;
 
-    // eslint-disable-next-line no-unused-expressions
-    p5.instance._renderer.uViewMatrix?.set(this._view.transform.inverse.matrix);
+    if (renderer.uViewMatrix) {
+      renderer.uViewMatrix.mat4 = this._view.transform.inverse.matrix;
+    }
 
     // has not effect in v1.10.0, but kept for older version
-    p5.instance._renderer.uMVMatrix.set(this._view.transform.inverse.matrix);
-    p5.instance._renderer.uPMatrix.set(this._view.projectionMatrix);
-    p5.instance._renderer._curCamera.cameraMatrix.set(
-      p5.Matrix.identity().mult(this._view.transform.inverse.matrix),
-    );
+    renderer.uMVMatrix.mat4 = this._view.transform.inverse.matrix;
+    renderer.uPMatrix.mat4 = this._view.projectionMatrix;
+
+    renderer._curCamera.cameraMatrix.mat4 = this._view.transform.inverse.matrix;
 
     if (newView.eye === 'left') {
       this.leftPMatrix.set(p5.instance._renderer.uPMatrix.copy());


### PR DESCRIPTION
Fixed #237

After **a lot** of trial and error, the non obvious step was setting the p5 camera matrices directly, because of some weird iframe context issues discussed here: https://github.com/ffd8/P5LIVE/issues/95#issuecomment-2360212101 

In my tests this does not seem to have any direct consequences, but still might be a change worth noting.

```js
      renderer.uViewMatrix.mat4 = this._view.transform.inverse.matrix;
```