### PR TITLE
fix: Reset matrix before draw

### DIFF
--- a/examples/ar/hello-cube/example.js
+++ b/examples/ar/hello-cube/example.js
@@ -4,8 +4,6 @@ function setup() {
 }
 
 function draw() {
-  push();
   translate(0, 0, -0.4);
   box(0.1, 0.1, 0.1);
-  pop();
 }

--- a/src/p5xr/core/p5xr.js
+++ b/src/p5xr/core/p5xr.js
@@ -449,7 +449,7 @@ export default class p5xr {
       if (typeof userSetup === 'undefined') {
         context.scale(context._pixelDensity, context._pixelDensity);
       }
-
+      context.resetMatrix();
       this.__updateXR();
 
       p5.instance._inUserDraw = true;


### PR DESCRIPTION
This seems to fix #243

Might be worth looking into why it worked without this in versions 1.9.4 and backwards.