### PR TITLE
fix: add WEBGL parameters to createGraphics()

### DIFF
--- a/examples/immersive-360/basic/exampleB.js
+++ b/examples/immersive-360/basic/exampleB.js
@@ -14,7 +14,7 @@ function preload() {
 
 function setup() {
   setVRBackgroundColor(0,0,0);
-  graphics = createGraphics(600,600);
+  graphics = createGraphics(600,600, WEBGL);
 }
 
 function draw() {

--- a/examples/immersive-360/complex/exampleC.js
+++ b/examples/immersive-360/complex/exampleC.js
@@ -46,7 +46,7 @@ function preload() {
 
 function setup() {
   setVRBackgroundColor(0, 0, 0);
-  graphics = createGraphics(800, 800);
+  graphics = createGraphics(800, 800, WEBGL);
 }
 
 function draw() {

--- a/examples/immersive-typography/complex/example.js
+++ b/examples/immersive-typography/complex/example.js
@@ -33,13 +33,13 @@ function setup() {
     sampleFactor: samplefact,
   });
 
-  gold = createGraphics(600, 600);
+  gold = createGraphics(600, 600, WEBGL);
   gold.background(255, 80);
 
-  ring = createGraphics(600, 600);
+  ring = createGraphics(600, 600, WEBGL);
   ring.background(5);
 
-  letter = createGraphics(200, 200);
+  letter = createGraphics(200, 200, WEBGL);
 
   for (let i = 0; i < 10; ++i) {
     randomX[i] = random(-800, 800);

--- a/examples/physics/complex/example.js
+++ b/examples/physics/complex/example.js
@@ -39,7 +39,7 @@ function preload() {
 
 function setup() {
   setVRBackgroundColor(255, 255, 255);
-  textGraphics = createGraphics(600, 600);
+  textGraphics = createGraphics(600, 600, WEBGL);
   textGraphics.background(0, 0, 0);
 
   ground = new Boundary(0, -3, 0, 20, 1, 20, 1, -1, 1);


### PR DESCRIPTION
Some examples can not run due to `createGraphics()`  was not given a WEBGL parameter